### PR TITLE
Admin order receipt approval and rejection

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -651,7 +651,23 @@ def handle_admin_callback(call):
             order_id = int(call.data.replace("admin_view_orders_ss_", ""))
             order = db.get_order(order_id)
             if order and order.get('screenshot_file_id'):
-                bot.send_photo(call.message.chat.id, order['screenshot_file_id'], caption=f"🧾 سفارش #{order_id} - اسکرین‌شات پرداخت")
+                keyboard = InlineKeyboardMarkup()
+                keyboard.add(
+                    InlineKeyboardButton("✅ تایید", callback_data=f"admin_approve_order_{order_id}"),
+                    InlineKeyboardButton("❌ رد", callback_data=f"admin_reject_order_{order_id}")
+                )
+                keyboard.add(InlineKeyboardButton("🔙 بازگشت", callback_data=f"admin_view_order_{order_id}"))
+                caption = (
+                    f"🧾 سفارش #{order_id}\n"
+                    f"اسکرین‌شات پرداخت"
+                )
+                bot.send_photo(
+                    call.message.chat.id,
+                    order['screenshot_file_id'],
+                    caption=caption,
+                    parse_mode='Markdown',
+                    reply_markup=keyboard
+                )
             else:
                 bot.answer_callback_query(call.id, "❌ اسکرین‌شات موجود نیست")
         except ValueError:


### PR DESCRIPTION
Add inline 'Approve', 'Reject', and 'Back' buttons to the admin order payment screenshot view to enable direct action and navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-4578128f-3cee-4028-bd2f-091f5f926015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4578128f-3cee-4028-bd2f-091f5f926015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

